### PR TITLE
Add support for optional 'noStrict' parameter in Transaction.fromBuffer

### DIFF
--- a/lib/src/transaction.dart
+++ b/lib/src/transaction.dart
@@ -411,7 +411,10 @@ class Transaction {
     return tx;
   }
 
-  factory Transaction.fromBuffer(Uint8List buffer) {
+  factory Transaction.fromBuffer(
+    Uint8List buffer, {
+    bool noStrict = false,
+  }) {
     var offset = 0;
     // Any changes made to the ByteData will also change the buffer, and vice versa.
     // https://api.dart.dev/stable/2.7.1/dart-typed_data/ByteBuffer/asByteData.html
@@ -501,6 +504,8 @@ class Transaction {
 
     tx.locktime = readUInt32();
 
+    if (noStrict) return tx;
+
     if (offset != buffer.length)
       throw new ArgumentError('Transaction has unexpected data');
 
@@ -508,7 +513,10 @@ class Transaction {
   }
 
   factory Transaction.fromHex(String hex) {
-    return Transaction.fromBuffer(HEX.decode(hex));
+    return Transaction.fromBuffer(
+      HEX.decode(hex),
+      noStrict: true,
+    );
   }
 
   @override

--- a/lib/src/transaction.dart
+++ b/lib/src/transaction.dart
@@ -512,10 +512,13 @@ class Transaction {
     return tx;
   }
 
-  factory Transaction.fromHex(String hex) {
+  factory Transaction.fromHex(
+    String hex, {
+    bool noStrict = false,
+  }) {
     return Transaction.fromBuffer(
       HEX.decode(hex),
-      noStrict: true,
+      noStrict: noStrict,
     );
   }
 


### PR DESCRIPTION
We added this parameter to be able to return a transaction without failing due to offset check.

The motivation for this comes from the bitcoinjs library as shown in the following links:
- https://github.com/bitcoinjs/bitcoinjs-lib/blob/533d6c2e6d0aa4111f7948b1c12003cf6ef83137/ts_src/transaction.ts#L69
- https://github.com/bitcoinjs/bitcoinjs-lib/blob/533d6c2e6d0aa4111f7948b1c12003cf6ef83137/ts_src/transaction.ts#L119